### PR TITLE
Use keyword arguments for train.py train

### DIFF
--- a/training/train.py
+++ b/training/train.py
@@ -231,6 +231,19 @@ if __name__ == "__main__":
     parser.add_argument("-c", "--checkpoint_path", required=False, type=str, help="checkpoint path")
     parser.add_argument("-e", "--epochs", default=8000, type=int, help="num epochs")
     parser.add_argument("-b", "--batch_size", required=False, type=int, help="batch size")
+    parser.add_argument(
+        "-t",
+        "--transfer_learning_path",
+        required=False,
+        type=str,
+        help="path to an model to transfer learn from",
+    )
+    parser.add_argument(
+        "--overwrite_checkpoints",
+        default=False,
+        type=bool,
+        help="whether to delete old checkpoints",
+    )
 
     args = parser.parse_args()
 
@@ -246,4 +259,6 @@ if __name__ == "__main__":
         checkpoint_path=args.checkpoint_path,
         epochs=args.epochs,
         batch_size=args.batch_size,
+        transfer_learning_path=args.transfer_learning_path,
+        overwrite_checkpoints=args.overwrite_checkpoints,
     )

--- a/training/train.py
+++ b/training/train.py
@@ -240,10 +240,10 @@ if __name__ == "__main__":
         assert os.path.isfile(args.checkpoint_path)
 
     train(
-        args.metadata_path,
-        args.dataset_directory,
-        args.output_directory,
-        args.checkpoint_path,
-        args.epochs,
-        args.batch_size,
+        metadata_path=args.metadata_path,
+        dataset_directory=args.dataset_directory,
+        output_directory=args.output_directory,
+        checkpoint_path=args.checkpoint_path,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
     )


### PR DESCRIPTION
If you got to the [function definition for train](https://github.com/brooklynbagel/Voice-Cloning-App/blob/90b8f81c53b87984d8400c5f7e345d29a8c6321a/training/train.py#L39) the arguments are, in order,

1. `metadata_path`
2. `dataset_directory`
3. `output_directory`
4. `alphabet_path`
5. `checkpoint_path`
6. `transfer_learning_path`
7. `overwrite_checkpoints`
8. `epochs`
9. `batch_size`
10. `early_stopping`
11. `multi_gpu`
12. `iters_per_checkpoint`
13. `train_size`
14. `logging`

When the function is being called without using key words arguments, the first three command line arguments correspond to the correct function argument, but the command line arguments `checkpoint_path`, `epochs` and `batch_size` get passed as `alphabet_path`, `checkpoint_path` and `transfer_learning_path` respectively. Passing the arguments as keyword arguments is meant to remedy this.