### PR TITLE
Insert project root to front of sys.path

### DIFF
--- a/dataset/create_dataset.py
+++ b/dataset/create_dataset.py
@@ -3,7 +3,7 @@ import logging
 from os.path import dirname, abspath
 import sys
 
-sys.path.append(dirname(dirname(abspath(__file__))))
+sys.path.insert(0, dirname(dirname(abspath(__file__))))
 
 from dataset.audio_processing import convert_audio
 from dataset.clip_generator import clip_generator

--- a/dataset/extend_existing_dataset.py
+++ b/dataset/extend_existing_dataset.py
@@ -4,7 +4,7 @@ import os
 from os.path import dirname, abspath
 import sys
 
-sys.path.append(dirname(dirname(abspath(__file__))))
+sys.path.insert(0, dirname(dirname(abspath(__file__))))
 
 from dataset.audio_processing import convert_audio
 from dataset.clip_generator import extend_dataset

--- a/synthesis/synthesize.py
+++ b/synthesis/synthesize.py
@@ -9,7 +9,7 @@ from scipy.io.wavfile import write
 from os.path import dirname, abspath
 import sys
 
-sys.path.append(dirname(dirname(abspath(__file__))))
+sys.path.append(0, dirname(dirname(abspath(__file__))))
 matplotlib.use("Agg")
 
 import glow  # noqa

--- a/training/train.py
+++ b/training/train.py
@@ -6,7 +6,7 @@ import logging
 from os.path import dirname, abspath
 import sys
 
-sys.path.append(dirname(dirname(abspath(__file__))))
+sys.path.insert(0, dirname(dirname(abspath(__file__))))
 logging.getLogger().setLevel(logging.INFO)
 
 import torch


### PR DESCRIPTION
Proposed fix 1 for #55. This gives the root of the project directory precedence over any of the directories the `.py` files live in since it is added to the front of `sys.path`, not the back.

One caveat: I can't run everything locally since I don't have a GPU, however a look at the code looks like you're doing a lot of imports from the top level directory anyway (`from training.dataset ...`, `from synthesis.vocoders ...`, etc) so I don't think it should cause any collisions. 