### PR TITLE
Fix multi line synthesis

### DIFF
--- a/application/views.py
+++ b/application/views.py
@@ -313,7 +313,10 @@ def synthesis_post():
         split_text = method == "paragraph"
         parent_folder = os.path.join(paths["results"], datetime.now().strftime("%Y-%m"))
         os.makedirs(parent_folder, exist_ok=True)
-        results_folder = os.path.join(parent_folder, get_suffix() + "-" + text.replace(" ", "_")[:20])
+        first_line=text
+        if(type(first_line)==list):
+            first_line=first_line[0]
+        results_folder = os.path.join(parent_folder, get_suffix() + "-" + first_line.replace(" ", "_")[:20])
         os.makedirs(results_folder)
         graph_path = os.path.join(results_folder, GRAPH_FILE)
         audio_path = os.path.join(results_folder, RESULTS_FILE)


### PR DESCRIPTION
The synthesis route was blindly calling .replace on text without making sure it was a string first. If you tried to use the Multi Line method on the synthesis page text was a list type instead of a string and the folder name creation would throw an exception. The single line and paragraph methods correctly typed text as a string. The later synthesize() call already correctly handled text as a list or string type. 