### PR TITLE
Fix dataset creation for datasets >24h

### DIFF
--- a/dataset/clip_generator.py
+++ b/dataset/clip_generator.py
@@ -14,7 +14,7 @@ from dataset.forced_alignment.search import FuzzySearch
 from dataset.forced_alignment.audio import DEFAULT_RATE
 from dataset.audio_processing import change_sample_rate, cut_audio, add_silence
 from training import DEFAULT_ALPHABET, PUNCTUATION
-
+from pytimeparse.timeparse import timeparse
 
 def clip_combiner(audio_path, output_path, clips, max_length):
     """
@@ -39,7 +39,7 @@ def clip_combiner(audio_path, output_path, clips, max_length):
 
     def _get_duration(start, end):
         """Gets the duration in seconds between two string timestamps"""
-        return (datetime.strptime(end, "%H:%M:%S.%f") - datetime.strptime(start, "%H:%M:%S.%f")).total_seconds()
+        return (timeparse(end) - timeparse(start))
 
     def _join_text(lines):
         """Joins list of lines with comma seperation"""

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -19,3 +19,4 @@ deepspeech==0.9.3
 llvmlite==0.32.1
 pysrt==1.1.2
 nltk==3.6.2
+pytimeparse==1.1.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ deepspeech==0.9.3
 llvmlite==0.32.1
 pysrt==1.1.2
 nltk==3.6.2
+pytimeparse==1.1.8


### PR DESCRIPTION
With the old implementation dataset creation would fail if the datasets total length exceeded 24h. This change requires an additional package (pytimeparse).