### PR TITLE
Dependencies: set fix version for dependencies

### DIFF
--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -21,3 +21,6 @@ llvmlite==0.32.1
 pysrt==1.1.2
 nltk==3.6.2
 pytimeparse==1.1.8
+itsdangerous==2.0.1
+werkzeug==2.0.3
+joblib==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,6 @@ llvmlite==0.32.1
 pysrt==1.1.2
 nltk==3.6.2
 pytimeparse==1.1.8
+itsdangerous==2.0.1
+werkzeug==2.0.3
+joblib==1.1.0


### PR DESCRIPTION
itsdangerous, werkzeug, joblib should be locked at an older revision for the docker build to succeed.

Signed-off-by: Nicolae Natea <nicu@natea.ro>