### PR TITLE
Fix Websockets not working

### DIFF
--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -24,3 +24,4 @@ pytimeparse==1.1.8
 itsdangerous==2.0.1
 werkzeug==2.0.3
 joblib==1.1.0
+python-socketio==5.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ pytimeparse==1.1.8
 itsdangerous==2.0.1
 werkzeug==2.0.3
 joblib==1.1.0
+python-socketio==5.5.0


### PR DESCRIPTION
This will cause python-socketio to be downgraded to version 5.5.0. As otherwise the frontend will somehow not receive any messeges via websockets. Should fix #160